### PR TITLE
feat: add syntax highlighting for input n output

### DIFF
--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
+	import { highlightKeywords } from '$lib/utils/index.svelte';
 
 	let {
 		query,
@@ -19,6 +20,10 @@
 	];
 	let currentPlaceholder = $state(0);
 
+	let styledQuery = $state(query);
+
+	let splitQuery = $derived(query.split(' '));
+
 	onMount(() => {
 		inputElement.focus();
 
@@ -32,6 +37,7 @@
 			onsubmit(query);
 			updateQueryString();
 			query = '';
+			styledQuery = '';
 		}
 	}
 
@@ -43,16 +49,30 @@
 	onMount(() => {
 		const params = new URLSearchParams(location.search);
 		query = params.get('query') || '';
+		styledQuery = highlightKeywords(splitQuery);
 	});
 </script>
 
 <div class="p-8 text-2xl gap-4 flex justify-center items-center">
 	<span class="text-pink whitespace-nowrap italic"> EQL > </span>
-	<input
-		bind:this={inputElement}
-		bind:value={query}
-		class="w-full bg-dim-1 focus:outline-none"
-		placeholder={placeholders[currentPlaceholder]}
-		onkeypress={handleKeyPress}
-	/>
+	<div class="relative w-full">
+		<div
+			contenteditable
+			role="textbox"
+			bind:textContent={query}
+			bind:innerHTML={styledQuery}
+			spellcheck="false"
+			class="w-fit bg-dim-1 focus:outline-none absolute z-10 text-white"
+		></div>
+		<input
+			bind:this={inputElement}
+			bind:value={query}
+			class="w-full bg-dim-1 focus:outline-none"
+			placeholder={placeholders[currentPlaceholder]}
+			onkeypress={handleKeyPress}
+			oninput={() => {
+				styledQuery = highlightKeywords(splitQuery);
+			}}
+		/>
+	</div>
 </div>

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -57,12 +57,14 @@
 	<span class="text-pink whitespace-nowrap italic"> EQL > </span>
 	<div class="relative w-full">
 		<div
+			tabindex="0"
 			contenteditable
 			role="textbox"
 			bind:textContent={query}
 			bind:innerHTML={styledQuery}
+			onkeypress={handleKeyPress}
 			spellcheck="false"
-			class="w-fit bg-dim-1 focus:outline-none absolute z-10 text-white"
+			class="w-fit bg-dim-1 focus:outline-none absolute z-10"
 		></div>
 		<input
 			bind:this={inputElement}

--- a/src/lib/components/Results.svelte
+++ b/src/lib/components/Results.svelte
@@ -4,6 +4,7 @@
 	import { openModal } from '$lib/stores/modal.svelte';
 	import Share from './Share.svelte';
 	import Spinner from './Spinner.svelte';
+	import { highlightKeywords } from '$lib/utils/index.svelte';
 
 	let lastItem = $derived(queryHandler.results.length);
 	let fetching = $derived(queryHandler.fetchingQuery);
@@ -36,7 +37,7 @@
 			<div class="flex flex-col gap-2" class:last={index === queryHandler.results.length - 1}>
 				<div>
 					<span class="text-lg">
-						> {result.query}
+						> {@html highlightKeywords(result.query.split(' '))}
 						<button
 							onclick={() => openModal(shareQuery, { dismissible: true, param: result.query })}
 							class="text-gray text-sm">Share</button

--- a/src/lib/utils/index.svelte.ts
+++ b/src/lib/utils/index.svelte.ts
@@ -7,19 +7,19 @@ export function highlightKeywords(q: string[]) {
     .map((word) => {
       if (keywords.has(word)) {
         beforeWord = word;
-        return `<span class="text-purple-700">${word}</span>`;
+        return `<span style="color: #BCB3FA">${word}</span>`;
       } else {
         if (beforeWord === 'ON') {
           beforeWord = word;
           entity = '';
-          return `<span class="text-amber-200">${word}</span>`;
+          return `<span style="color: #EDCF7A">${word}</span>`;
         } else if (beforeWord === 'FROM') {
           beforeWord = word;
           entity = word;
           return word;
         } else if (entity !== '') {
           beforeWord = word;
-          return `<span class="text-amber-200">${word}</span>`;
+          return `<span style="color: #EDCF7A">${word}</span>`;
         } else {
           beforeWord = word;
           return word;

--- a/src/lib/utils/index.svelte.ts
+++ b/src/lib/utils/index.svelte.ts
@@ -1,0 +1,30 @@
+const keywords = new Set(['GET', 'FROM', 'ON', 'WHERE']);
+
+export function highlightKeywords(q: string[]) {
+  let beforeWord: string = '';
+  let entity: string = '';
+  return q
+    .map((word) => {
+      if (keywords.has(word)) {
+        beforeWord = word;
+        return `<span class="text-purple-700">${word}</span>`;
+      } else {
+        if (beforeWord === 'ON') {
+          beforeWord = word;
+          entity = '';
+          return `<span class="text-amber-200">${word}</span>`;
+        } else if (beforeWord === 'FROM') {
+          beforeWord = word;
+          entity = word;
+          return word;
+        } else if (entity !== '') {
+          beforeWord = word;
+          return `<span class="text-amber-200">${word}</span>`;
+        } else {
+          beforeWord = word;
+          return word;
+        }
+      }
+    })
+    .join(' ');
+}


### PR DESCRIPTION
closes #3 

the syntax highlighting uses <div> tags for showing over the input. please tell if there is a better solution.

does the colors need to be included also on tailwind?

tested from a handful sample of queries and it works (also uses the placeholder queries)